### PR TITLE
Bugfix/build report redirect loop

### DIFF
--- a/app/controllers/admin/auditor_controller.rb
+++ b/app/controllers/admin/auditor_controller.rb
@@ -78,11 +78,11 @@ class Admin::AuditorController < ApplicationController
  
     report = @org.report_archives.find(params[:report])
  
-    unless report.present? && report.report_filters['account_filter'] == "#{@account_filter}" && rebuild
+    unless report.present? && report.report_filters['account_filter'] == "#{@account_filter}"
       report = @org.report_archives.all.find {|r| r.report_filters['account_filter'] == "#{@account_filter}" && !r.is_archived }
     end
  
-    if report.present?
+    if report.present? && rebuild
       generate_report(report.id)
     else
       generate_report()

--- a/app/controllers/admin/auditor_controller.rb
+++ b/app/controllers/admin/auditor_controller.rb
@@ -57,13 +57,13 @@ class Admin::AuditorController < ApplicationController
   end
 
   def report
-    @params_hash = params.permit(:account_filter, :controller, :action).to_hash
-    rebuild = params[:rebuild]
+    #@params_hash = params.permit(:account_filter, :controller, :action).to_hash
+    #rebuild = params[:rebuild]
     
-    remove_unneeded_params
+    #remove_unneeded_params
 
-    @account_filter = get_account_filter
-    params[:account_filter] = @account_filter
+    #@account_filter = get_account_filter
+    #params[:account_filter] = @account_filter
     # @account_filter = {"account_filter":"FL17"}
 
     @report = get_report
@@ -71,26 +71,29 @@ class Admin::AuditorController < ApplicationController
     
     return redirect_to admin_auditor_reports_path(org_path:params[:org_path]) if @report.blank?
 
-    if rebuild && @report.present?
-      redirect_if_job_incomplete
-      report_id = @report.id
-      generate_report(report_id)
-      redirect_to admin_auditor_report_status_path(org_path:params[:org_path])
-    elsif @report.blank?
-      redirect_if_job_incomplete
-      generate_report()
-      redirect_to admin_auditor_report_status_path(org_path:params[:org_path])
-    else
-      if !@report.payload && !@queued
-        generate_report(@report.id)
-        return redirect_to admin_auditor_report_status_path(org_path:params[:org_path])
-      end
-      @name_by = get_name_reports_by
-      report_payload = @report.parsed_payload
-      @chart_data = prep_chart_data_for_hichart(report_payload)
-      @report_data = report_payload['list']
-      render 'report', layout: '../admin/auditor/report_layout'
-    end
+    #if rebuild && @report.present?
+    #  redirect_if_job_incomplete
+    #  report_id = @report.id
+    #  generate_report(report_id)
+    #  redirect_to admin_auditor_report_status_path(org_path:params[:org_path])
+    #elsif @report.blank?
+    #  redirect_if_job_incomplete
+    #  generate_report()
+    #  redirect_to admin_auditor_report_status_path(org_path:params[:org_path])
+    # if true
+    #if !@report.payload && !@queued
+    #  generate_report(@report.id)
+    #  return redirect_to admin_auditor_report_status_path(org_path:params[:org_path])
+    #end
+    #@report.payload if !@report.payload && !@queued
+    # @report.payload = nil
+    # @report.save
+    @name_by = get_name_reports_by
+    report_payload = @report.parsed_payload
+    @chart_data = prep_chart_data_for_hichart(report_payload)
+    @report_data = report_payload['list']
+    render 'report', layout: '../admin/auditor/report_layout'
+    # end
   end
 
   def build
@@ -173,7 +176,7 @@ class Admin::AuditorController < ApplicationController
     else
       #start by saving the report (add check to see if there is a report)
       reports = ReportArchive.where(organization_id: @org.id) 
-      if !reports.blank?
+      if reports.present?
           report = reports.count == 1
       else
         report = nil

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -11,7 +11,7 @@ module ReportHelper
     @report.save!(touch:false)
 
     # ReportHelper.generate_report Organization.find(org_id).slug, account_filter, params, @report.id
-    ReportGenerator.enqueue org_id, account_filter, params, @report.id 
+    #ReportGenerator.enqueue org_id, account_filter, params, @report.id 
   end
 
   def self.generate_report (org_slug, account_filter, params, report_id)

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -11,7 +11,7 @@ module ReportHelper
     @report.save!(touch:false)
 
     # ReportHelper.generate_report Organization.find(org_id).slug, account_filter, params, @report.id
-    #ReportGenerator.enqueue org_id, account_filter, params, @report.id 
+    ReportGenerator.enqueue org_id, account_filter, params, @report.id 
   end
 
   def self.generate_report (org_slug, account_filter, params, report_id)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -10,6 +10,7 @@ class Organization < ApplicationRecord
   has_many :user_assignments
   has_many :users, through: :user_assignments
   has_many :workflow_steps
+  has_many :report_archives
 
   before_validation :use_nil_for_blank_name_reports_by
   before_validation :use_nil_for_blank_time_zone

--- a/app/models/report_archive.rb
+++ b/app/models/report_archive.rb
@@ -2,6 +2,7 @@ class ReportArchive < ApplicationRecord
   belongs_to :organization
 
   def parsed_payload
+    return {:list=>[]} if self.payload.blank?
     data = JSON.parse(self.payload)
     return data if data.is_a?(Hash) 
     return {'list'=> data} if data.is_a?(Array)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
             get 'request_access', to: 'request_access'
 
             get 'report', to: 'auditor#report', as: 'auditor_report'
-            post 'report', to: 'auditor#report', as: 'auditor_generate_report'
+            post 'report', to: 'auditor#build', as: 'auditor_generate_report'
             get 'download', to: 'auditor#download', as: 'auditor_download'
 
             get 'report-status', to: 'auditor#reportStatus', as: 'auditor_report_status'


### PR DESCRIPTION
this is what it dose now:
when a client clicks build report

and the current reports matches the inputted account filter.
then rebuild the current report

when current reports dose not match the inputted account_filter
then look for a report within the org that has that account filter that is not archived.

when a matching report is found 
then rebuild that one

when a matching report is not found
create a new report with that account filter