### PR TITLE
Bugfix/report default bugs and refactor

### DIFF
--- a/app/controllers/admin/auditor_controller.rb
+++ b/app/controllers/admin/auditor_controller.rb
@@ -38,6 +38,7 @@ class Admin::AuditorController < ApplicationController
       organization_id: @org.id, 
       is_archived: params[:show_archived].present?).order(updated_at: :desc )
 
+    raise get_account_filter.inspect
     if @reports.blank? && !params[:show_archived]
       @params_hash = params.permit(:account_filter, :controller, :action, :period_filter).to_hash
 
@@ -136,18 +137,9 @@ class Admin::AuditorController < ApplicationController
   end
 
   def get_account_filter
-    if params[:account_filter] && params[:account_filter] != ""
-      return params[:account_filter]
-    else
-      if @org.root_org_setting("reports_use_document_meta")
-        default_account_filter = @org.root_org_setting('default_account_filter')&.dig('account_filter').inspect
-      else
-        default_account_filter = @org.all_periods.find_by(is_default:true)&.slug
-      end
-      if default_account_filter.present?
-        return default_account_filter
-      end
-    end
+    return params[:account_filter] if params[:account_filter] && params[:account_filter] != ""
+    return @org.root_org_setting('default_account_filter')&.dig('account_filter') if @org.root_org_setting("reports_use_document_meta")
+    return @org.all_periods.find_by(is_default:true)&.slug
   end
 
   def get_report

--- a/app/controllers/admin/auditor_controller.rb
+++ b/app/controllers/admin/auditor_controller.rb
@@ -127,7 +127,7 @@ class Admin::AuditorController < ApplicationController
   end
 
   def get_account_filter
-    return params[:account_filter] if params[:account_filter] && params[:account_filter] != ""
+    return params[:account_filter] if params[:account_filter].present?
     return @org.root_org_setting('default_account_filter')&.dig('account_filter') if @org.root_org_setting("reports_use_document_meta")
     return @org.all_periods.find_by(is_default:true)&.slug
   end

--- a/app/controllers/admin/auditor_controller.rb
+++ b/app/controllers/admin/auditor_controller.rb
@@ -41,8 +41,8 @@ class Admin::AuditorController < ApplicationController
     if @reports.blank? && !params[:show_archived]
       @params_hash = params.permit(:account_filter, :controller, :action, :period_filter).to_hash
 
-      report = ReportArchive.create({organization_id: @org.id, report_filters: @params_hash})
-      generate_report(report.id)
+      @period_filter = get_account_filter
+      generate_report()
       
       return redirect_to admin_auditor_reports_path(org_path:params[:org_path])
     end
@@ -60,7 +60,7 @@ class Admin::AuditorController < ApplicationController
   def report
     @report = get_report
     return redirect_to admin_auditor_reports_path(org_path:params[:org_path]) if @report.blank?
-    
+
     @name_by = get_name_reports_by
     report_payload = @report.parsed_payload
     @chart_data = prep_chart_data_for_hichart(report_payload)

--- a/app/controllers/admin/auditor_controller.rb
+++ b/app/controllers/admin/auditor_controller.rb
@@ -39,20 +39,22 @@ class Admin::AuditorController < ApplicationController
       is_archived: params[:show_archived].present?).order(updated_at: :desc )
 
     if @reports.blank? && !params[:show_archived]
+      
       @params_hash = params.permit(:account_filter, :controller, :action, :period_filter).to_hash
-
       @period_filter = get_account_filter
       generate_report()
       
       return redirect_to admin_auditor_reports_path(org_path:params[:org_path])
     end
 
+    # TODO remove this
     @default_report = nil
     @reports.each do |report|
       if report.payload && @org.default_account_filter && report.report_filters && report.report_filters["account_filter"] == @org.default_account_filter
         @default_report = true
       end
     end
+    # to here
 
     render 'reports', layout: '../admin/auditor/report_layout'
   end

--- a/app/controllers/admin/auditor_controller.rb
+++ b/app/controllers/admin/auditor_controller.rb
@@ -142,12 +142,24 @@ class Admin::AuditorController < ApplicationController
   end
 
   def get_report
+    #TODO refactor: 
+      
+    # return ReportArchive.find_by(id: params[:report]) if params[:report]
+    
+    # return ReportArchive.find_by(
+      # "organization_id = :org_id and is_archived = false and report_filters->>'account_filter' = :account_filter", {account_filter: get_account_filter, org_id: @org.id
+    # })
+    
+    # return ReportArchive.find_by(organization_id: @org.id, is_archived: false) ? maybe remove this line
+    # return ReportArchive.find_by(organization_id: @org.id) ? maybe remove this line
+       
     report = nil
     if params[:report]
-      report = ReportArchive.where(id: params[:report]).first
+      report = ReportArchive.where(id: params[:report]).first 
       params.delete :report
     else
       #start by saving the report (add check to see if there is a report)
+
       reports = ReportArchive.where(organization_id: @org.id) 
       if reports.present?
         report = reports.first
@@ -159,10 +171,12 @@ class Admin::AuditorController < ApplicationController
   end
 
   def remove_unneeded_params
+    # TODO: test if this is needed
     params.delete :authenticity_token
     params.delete :utf8
     params.delete :commit
     params.delete :rebuild
+    # params.delete :report
   end
   
 end

--- a/app/controllers/admin/auditor_controller.rb
+++ b/app/controllers/admin/auditor_controller.rb
@@ -38,7 +38,6 @@ class Admin::AuditorController < ApplicationController
       organization_id: @org.id, 
       is_archived: params[:show_archived].present?).order(updated_at: :desc )
 
-    raise get_account_filter.inspect
     if @reports.blank? && !params[:show_archived]
       @params_hash = params.permit(:account_filter, :controller, :action, :period_filter).to_hash
 

--- a/app/controllers/admin/auditor_controller.rb
+++ b/app/controllers/admin/auditor_controller.rb
@@ -140,17 +140,12 @@ class Admin::AuditorController < ApplicationController
       return params[:account_filter]
     else
       if @org.root_org_setting("reports_use_document_meta")
-        default_account_filter = @org.root_org_setting('default_account_filter')
+        default_account_filter = @org.root_org_setting('default_account_filter')&.dig('account_filter').inspect
       else
-        default_account_filter = @org.all_periods.find_by(is_default:true).slug
+        default_account_filter = @org.all_periods.find_by(is_default:true)&.slug
       end
       if default_account_filter.present?
         return default_account_filter
-      else
-        # jump 2 weeks ahead to allow staff to review things for upcoming semester
-        date = Date.today + 2.weeks
-        semester = ['SP','SU','FL'][((date.month - 1) / 4)]
-        return "#{semester}#{date.strftime("%y")}"
       end
     end
   end

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -4,6 +4,7 @@ require 'zip'
 module ReportHelper
   def self.generate_report_as_job (org_id, account_filter, params, report_id = nil)
     params = params.select {|k,p| p.present?}
+    # raise params.inspect
     if report_id
       @report = ReportArchive.find(report_id) if report_id
       @report.report_filters = params

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -4,7 +4,6 @@ require 'zip'
 module ReportHelper
   def self.generate_report_as_job (org_id, account_filter, params, report_id = nil)
     params = params.select {|k,p| p.present?}
-    # raise params.inspect
     if report_id
       @report = ReportArchive.find(report_id) if report_id
       @report.report_filters = params

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -9,6 +9,7 @@ class Document < ApplicationRecord
   belongs_to :period, optional: true
   belongs_to :workflow_step, optional: true
   belongs_to :user, optional: true
+  has_many :document_meta
   
   def self.abandoned()
     return 'documents.updated_at = documents.created_at'

--- a/app/models/document_meta.rb
+++ b/app/models/document_meta.rb
@@ -2,4 +2,6 @@ class DocumentMeta < ApplicationRecord
   validates_presence_of :key
   validates_presence_of :value
   validates_presence_of :lms_organization_id, :lms_course_id, :root_organization_id
+
+  belongs_to :document, optional: true
 end

--- a/app/models/report_archive.rb
+++ b/app/models/report_archive.rb
@@ -1,7 +1,6 @@
 class ReportArchive < ApplicationRecord
   
   belongs_to :organization
-  before_validation :use_default_on_blank_account_filter
 
   def parsed_payload
     return {:list=>[]} if self.payload.blank?
@@ -22,16 +21,6 @@ class ReportArchive < ApplicationRecord
   def set_used_document_meta(val)
     self.used_document_meta = val
     self.save
-  end
-
-  def use_default_on_blank_account_filter
-    if self.report_filters['account_filter'].blank?
-      if self.organization.root_org_setting("reports_use_document_meta")
-        self.report_filters['account_filter'] = "#{self.organization.root_org_setting('default_account_filter')}"
-      else
-        self.report_filters['account_filter'] = self.organization.periods.find_by(is_default: true).slug
-      end  
-    end
   end
 
   def filter_types filters = nil

--- a/app/views/admin/auditor/report.html.erb
+++ b/app/views/admin/auditor/report.html.erb
@@ -13,7 +13,7 @@
               <%= text_field_tag :account_filter, @report.report_filters["account_filter"], class: 'form-control' %>
             <% else %>
               <%= select_tag :account_filter, 
-                options_from_collection_for_select(@org.all_periods, "slug", "name", @report.report_filters["account_filter"].downcase),
+                options_from_collection_for_select(@org.all_periods, "slug", "name", @report.report_filters["account_filter"]),
                 include_blank: 'Default Period',
                 class: 'form-control'
               %>

--- a/app/views/admin/auditor/reports.html.erb
+++ b/app/views/admin/auditor/reports.html.erb
@@ -36,7 +36,9 @@
         </li>
         <%end%>
         <%if report.updated_at != report.created_at%>
+        <li>
           <%= timestamp_tag report.updated_at, prefix: "Last generated #{time_ago_in_words(report.updated_at)} ago at", time_zone: @time_zone, suffix: ""%>
+        </li>
         <%end%>
         <% if report.pretty_filters.present? %>
         <li>


### PR DESCRIPTION
when there was no default period  it would break the reports. that's now fixed.

bullet point was missing for timestamp_tag in reports.

the org setting for the default account filter for meta report now works again.
side note: in the database this setting is json ie {"account_filter":"FA17"}. it should be just a string "FA17". unless the setting should accept multiple filters.

removed the remove_unneeded_params method. I think at some point someone used this because they where unaware of .permit and .require.

because of use_default_on_blank_filter for reports_archive. and the "jump 2 weeks ahead" portion of the get account filter.
when no filters where set it generated a empty report.
now when no filters are set, it generates a report including all documents.
 
get report.
if report was nil it used to try to find a report. now the report action just redirects to reports if report is nil anyway.
