### PR TITLE
hotfix/fixed archived lti user issue

### DIFF
--- a/app/controllers/lti_controller.rb
+++ b/app/controllers/lti_controller.rb
@@ -74,7 +74,7 @@ class LtiController < ApplicationController
                 ]
             }
         end
-        if user.blank? && @organization.root_org_setting('lms_authentication_source') == "LTI"            
+        if (user.blank? || user.archived ) && @organization.root_org_setting('lms_authentication_source') == "LTI"             
             user_params = {
                 user: {
                     :name => @lti_info[:person_sourcedid],


### PR DESCRIPTION
if a user was archived and they tried to login through the lti they would see:
```
This account is inactive or Unassigned.
If you would like to request access click the link below.
```
it should instead unarchive that user.