### PR TITLE
Bugfix/select course fixes

### DIFF
--- a/app/controllers/admin/auditor_controller.rb
+++ b/app/controllers/admin/auditor_controller.rb
@@ -4,7 +4,7 @@ require 'zip'
 class Admin::AuditorController < ApplicationController
   
   before_action :require_auditor_role
-  before_action -> { @org = get_org }, olny: [:report, :reports, :build]
+  before_action -> { @org = get_org }, only: [:report, :reports, :build]
   before_action -> { get_org_time_zone @org }, only: [:report, :reports, :build]
 
   def download

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -27,7 +27,7 @@ class AdminController < ApplicationController
       :canvas_accounts,
       :canvas_courses
   ]
-  before_action :get_organization, olny: [:login,:authenticate,:search]
+  before_action :get_organization, only: [:login,:authenticate,:search]
 
   force_ssl only:[:canvas_courses, :canvas_accounts,:canvas_courses,:canvas_accounts_sync]
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -4,7 +4,7 @@ class DocumentsController < ApplicationController
   include DocumentsHelper
   layout 'view'
 
-  before_action :get_organization, olny: [:course_select, :course_link]
+  before_action :get_organization, only: [:course_select, :course_link]
   before_action :redirect_to_sub_org, only:[:index,:new,:show,:edit,:course, :course_list]
   before_action :x_frame_allow_all, only:[:new,:show,:edit,:course]
   before_action :lms_connection_information, :only => [:update, :edit, :course, :course_list]

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -148,7 +148,7 @@ class DocumentsController < ApplicationController
     else
       
       if existing_document?
-        if @organization.id != @existing_document.organization.id
+        if !existing_document_within_organization?
           flash[:error] = "Please contact an organization admin: The #{@course_id} course belongs to the 
           '#{@existing_document.organization.name}' organization, not '#{@organization.name}'."
         elsif !params[:document_token] && !force_course_link?

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -146,7 +146,8 @@ class DocumentsController < ApplicationController
       end
     end
     
-    get_lms_course @organization.setting('lms_authentication_source')
+    lms_authentication_source = @organization.setting('lms_authentication_source')
+    get_lms_course lms_authentication_source
 
     if @lms_course
       # see if there is a organization matched for course

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -243,6 +243,7 @@ class OrganizationsController < AdminController
         :time_zone, 
         :reports_use_document_meta, 
         :document_search_includes_sub_organizations,
+        :allow_existing_salsas_for_new_courses,
         :name_reports_by, 
         :default_account_filter, 
         default_account_filter: [:account_filter]

--- a/app/controllers/republish_controller.rb
+++ b/app/controllers/republish_controller.rb
@@ -2,7 +2,7 @@ require 'net/http'
 class RepublishController < ApplicationController
   before_action :require_organization_admin_permissions
   before_action :get_organization
-  before_action :get_org_time_zone, olny: [:preview]
+  before_action :get_org_time_zone, only: [:preview]
   before_action -> {@root_org = @organization.root}
   def preview
     get_documents

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -30,4 +30,9 @@ module DocumentsHelper
     end
   end
 
+  def existing_document_within_organization? org: @organization, doc: @existing_document
+    @is_existing_document_within_organization ||= @organization&.id == doc&.organization&.id
+  end
+
+
 end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -1,0 +1,17 @@
+module DocumentsHelper
+
+  def edit_document_or_lms_course_path( condition: params[:lms_course_id] ,**path_args) 
+    if condition
+        path_args.delete(:id) 
+        return lms_course_document_path( path_args )
+    else
+        path_args.delete(:lms_course_id)
+        return edit_document_path( path_args )
+    end
+  end
+
+  def existing_document?
+    @has_existing_document ||= @existing_document && !@existing_document&.same_record_as?(@document)
+  end
+
+end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -14,4 +14,20 @@ module DocumentsHelper
     @has_existing_document ||= @existing_document && !@existing_document&.same_record_as?(@document)
   end
 
+  def force_course_link?
+    has_role("organization_admin") && params[:relink] == "true"
+  end
+
+  def link_document_course document
+    if params[:lms_course_id] && document
+      if !document.link_course( lms_course_id: params[:lms_course_id], force: force_course_link?, token: params[:document_token])
+        flash[:error] = "Failed to link #{params[:lms_course_id]}"
+        false
+      else
+        flash[:notice] = "Successfully linked the #{params[:lms_course_id]} course id to this document"
+        true
+      end
+    end
+  end
+
 end

--- a/app/models/concerns/record_comparison.rb
+++ b/app/models/concerns/record_comparison.rb
@@ -6,4 +6,8 @@ module RecordComparison
     return record.is_a?(self.class) && record.id == self.id
   end
 
+  def separate_record_from? record
+    return record.is_a?(self.class) && record.id != self.id
+  end
+
 end

--- a/app/models/concerns/record_comparison.rb
+++ b/app/models/concerns/record_comparison.rb
@@ -1,0 +1,9 @@
+
+module RecordComparison
+  extend ActiveSupport::Concern
+  
+  def same_record_as? record
+    return record.is_a?(self.class) && record.id == self.id
+  end
+
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -198,9 +198,10 @@ class Document < ApplicationRecord
     populate_default_name
   end
 
-  def link_course lms_course_id , relink: false, document: nil
+  def link_course lms_course_id:, force: false, token: nil, document: nil
     document ||= Document.find_by( lms_course_id: lms_course_id, organization_id: self.organization.root.self_and_descendants )
-    if document.blank? || relink
+    force ||= document.separate_record_from?(Document.find_by( view_id: token)) if token && document
+    if document.blank? || force
       document&.lms_course_id = nil
       document&.save
       self.lms_course_id = lms_course_id
@@ -208,7 +209,7 @@ class Document < ApplicationRecord
     end
     return false
   end
-  
+
   protected
 
   def populate_default_name

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -206,20 +206,9 @@ class Document < ApplicationRecord
       self.lms_course_id = lms_course_id
       return self.save
     end
-    #   self.lms_course_id = lms_course_id
-    #   return self.save
-    # end
     return false
   end
-
-  def steal_course_from old_course_doc
-    self.steal_record :lms_course_id, old_course_doc
-    # self.lms_course_id = old_course_doc.lms_course_id
-    # old_course_doc.lms_course_id = nil
-    # old_course_doc.save
-    self
-  end
-
+  
   protected
 
   def populate_default_name

--- a/app/views/admin_documents/_list.html.haml
+++ b/app/views/admin_documents/_list.html.haml
@@ -1,6 +1,7 @@
 - titles ||= {}
 - classes ||= {}
 - course_id ||= nil
+- relink ||= nil
 - links = Hash[links.collect { |i| [i, true] } ]
 - columns = Hash[columns.collect { |i| [i, true] } ]
 
@@ -35,7 +36,7 @@
 
   %tbody
     - @documents.each do |document|
-      - org_base = org_url_base(document.organization)
+      - org_path = document.organization.path
       %tr{id: "document_#{document.id}_wrapper"}
         - if columns[:move_documents]
           %td= check_box_tag "document_ids[]", document.id, false, { id: "document_#{document.id}", 'aria-labeldedby': "document_#{document.id}_name" }
@@ -43,7 +44,7 @@
         - if columns[:name]
           %th{scope:"row", nowrap: "width='50%'"}
             - if has_role('supervisor') || has_role('designer') 
-              = link_to document.title, edit_admin_document_path(document, org_path: params[:org_path]), id: "document_#{document.id}_name"
+              = link_to document.title, edit_admin_document_path(document, org_path: org_path), id: "document_#{document.id}_name"
             - else
               = document.title
       
@@ -55,7 +56,7 @@
         
         - if columns[:lms_course_id] && !lms_authentication_source.nil?
           - if links[:link] && document.lms_course_id.blank?
-            %td= link_to titles[:link] || "Link", "#{org_base}#{lms_course_link_path(lms_course_id:course_id,edit_id:document.edit_id)}", class: classes[:link], 'data-document-id'=>document.id 
+            %td= link_to titles[:link] || "Link", link_lms_course_path(lms_course_id:course_id,id:document.edit_id, org_path: org_path, relink: relink ), class: classes[:link], 'data-document-id'=>document.id 
           - else
             %td{nowrap: ''}= document.lms_course_id
       
@@ -74,32 +75,32 @@
             .ul.horizontal-list
               
               - if links[:view] 
-                %li= link_to titles[:view] || "View", "#{org_base}#{document_path(id: document.view_id, org_path: params[:org_path])}", org_path: params[:org_path], target: :_blank
+                %li= link_to titles[:view] || "View", document_path(id: document.view_id, org_path: org_path), target: :_blank, class: classes[:view]
                 
               - if links[:info] && (has_role('supervisor') || has_role('designer'))
-                %li= link_to "Info", edit_admin_document_path(document, org_path: params[:org_path]), id: "document_#{document.id}_edit_info"
+                %li= link_to "Info", edit_admin_document_path(document, org_path: org_path), id: "document_#{document.id}_edit_info"
                 
               - if document.organization && document.organization.root_org_setting('enable_anonymous_actions')
                 - if links[:editor]
-                  %li= link_to "Editor", "#{org_base}#{document_path(id: document.edit_id, org_path: params[:org_path])}", org_path: params[:org_path]
+                  %li= link_to "Editor", document_path(id: document.edit_id, org_path: org_path)
                   
                 - if links[:template] && document.template_id
-                  %li= link_to (titles[:template] || "Template"), "#{org_base}#{document_path(id: document.template_id, org_path: params[:org_path], lms_course_id: course_id)}", org_path: params[:org_path], class: classes[:template]
+                  %li= link_to (titles[:template] || "Template"), document_path(id: document.template_id, org_path: org_path, lms_course_id: course_id, relink: relink), class: classes[:template]
               
               - if document.lms_course_id
                 - if links[:course] 
-                  %li= link_to "Course", "#{org_base}#{lms_course_document_path(lms_course_id: document.lms_course_id, org_path: params[:org_path])}", org_path: params[:org_path]
+                  %li= link_to "Course", lms_course_document_path(lms_course_id: document.lms_course_id, org_path: org_path)
                 
                 - if links[:published] && lms_authentication_source != "lti" && lms_authentication_source.present?
                   %li
                     %a{href:"#{lms_authentication_source}/courses/#{document.lms_course_id}/assignments/syllabus"}Published
 
                 - if links[:workflow] && document.user_id && enable_workflows
-                  %li= link_to "Workflow", organization_user_document_workflow_assignments_path(organization_user_id: document.user_id,org_path: params[:org_path],slug: params[:slug],document_id: document.id)
+                  %li= link_to "Workflow", organization_user_document_workflow_assignments_path(organization_user_id: document.user_id,org_path: org_path,slug: params[:slug],document_id: document.id)
 
                 - if links[:meta] && has_role('designer') && track_meta_info_from_document
                   %li= link_to "Meta",document_meta_path(document_id: document.id)
 
         - if columns[:version]
-          %td.text-right= link_to document.versions.count, admin_document_versions_path(document, org_path: params[:org_path])
+          %td.text-right= link_to document.versions.count, admin_document_versions_path(document, org_path: org_path)
 = paginate @documents

--- a/app/views/admin_documents/_list.html.haml
+++ b/app/views/admin_documents/_list.html.haml
@@ -12,7 +12,7 @@
 - @time_zone ||= @organization.setting("time_zone")
 
 = paginate @documents
-%table.table.table-responsive.striped
+%table.table.table-responsive
   %thead
     %tr
       - if columns[:move_documents]
@@ -70,7 +70,7 @@
             = timestamp_tag document.created_at, prefix: "Created", time_zone: @time_zone
 
         - if columns[:links]
-          %td{nowrap: ''}
+          %td{scope:"row", nowrap: ''}
             #document_links
             .ul.horizontal-list
               

--- a/app/views/admin_documents/_list.html.haml
+++ b/app/views/admin_documents/_list.html.haml
@@ -56,7 +56,7 @@
         
         - if columns[:lms_course_id] && !lms_authentication_source.nil?
           - if links[:link] && document.lms_course_id.blank?
-            %td= link_to titles[:link] || "Link", link_lms_course_path(lms_course_id:course_id,id:document.edit_id, org_path: org_path, relink: relink ), class: classes[:link], 'data-document-id'=>document.id 
+            %td= link_to titles[:link] || "Link", link_lms_course_path(lms_course_id:course_id,id:document.view_id, org_path: org_path, relink: relink ), class: classes[:link], 'data-document-id'=>document.id 
           - else
             %td{nowrap: ''}= document.lms_course_id
       

--- a/app/views/documents/_relink.html.haml
+++ b/app/views/documents/_relink.html.haml
@@ -1,6 +1,3 @@
-
-
-
 .d-inline-flex
   -if existing_document?
     - org_path = @existing_document.organization.path

--- a/app/views/documents/_relink.html.haml
+++ b/app/views/documents/_relink.html.haml
@@ -1,0 +1,14 @@
+
+
+#relink_options
+  .d-inline-flex
+    -if existing_document?
+      - org_path = @existing_document.organization.path
+      - if has_role("organization_admin", @existing_document.organization)
+        =link_to "Relink", lms_course_select_path(lms_course_id: params[:lms_course_id] ,org_path: org_path, relink: true), class: "btn btn-lg btn-link" unless params[:relink]
+        =link_to "Admin", edit_admin_document_path(@existing_document ,org_path: org_path), class: "btn btn-lg btn-link"
+      =link_to "Preview", document_path(id: @existing_document.view_id, org_path: org_path), target: :_blank, class: "btn btn-lg btn-default"
+      =link_to "Go to the exisitng SALSA", lms_course_document_path(lms_course_id: @course_id, org_path: org_path), class: "btn btn-lg btn-primary"
+      =link_to 'Use the SALSA as a template', template_document_path(lms_course_id: @course_id, id: @existing_document.template_id, org_path: params[:org_path], relink: true), {class: 'btn btn-lg btn-primary'}
+
+    =link_to "Create a new SALSA", new_document_path(lms_course_id: @course_id, org_path: params[:org_path], name: @lms_course['name']), class: "btn btn-lg btn-success"

--- a/app/views/documents/_relink.html.haml
+++ b/app/views/documents/_relink.html.haml
@@ -1,14 +1,13 @@
 
 
-#relink_options
-  .d-inline-flex
-    -if existing_document?
-      - org_path = @existing_document.organization.path
-      - if has_role("organization_admin", @existing_document.organization)
-        =link_to "Relink", lms_course_select_path(lms_course_id: params[:lms_course_id] ,org_path: org_path, relink: true), class: "btn btn-lg btn-link" unless params[:relink]
-        =link_to "Admin", edit_admin_document_path(@existing_document ,org_path: org_path), class: "btn btn-lg btn-link"
-      =link_to "Preview", document_path(id: @existing_document.view_id, org_path: org_path), target: :_blank, class: "btn btn-lg btn-default"
-      =link_to "Go to the exisitng SALSA", lms_course_document_path(lms_course_id: @course_id, org_path: org_path), class: "btn btn-lg btn-primary"
-      =link_to 'Use the SALSA as a template', template_document_path(lms_course_id: @course_id, id: @existing_document.template_id, org_path: params[:org_path], relink: true), {class: 'btn btn-lg btn-primary'}
 
-    =link_to "Create a new SALSA", new_document_path(lms_course_id: @course_id, org_path: params[:org_path], name: @lms_course['name']), class: "btn btn-lg btn-success"
+.d-inline-flex
+  -if existing_document?
+    - org_path = @existing_document.organization.path
+    - if has_role("organization_admin", @existing_document.organization)
+      =link_to "Admin", edit_admin_document_path(@existing_document ,org_path: org_path), class: "btn btn-lg btn-link"
+    =link_to "Preview", document_path(id: @existing_document.view_id, org_path: org_path), target: :_blank, class: "btn btn-lg btn-default"
+    =link_to "Go to the exisitng SALSA", lms_course_document_path(lms_course_id: @course_id, org_path: org_path), class: "btn btn-lg btn-primary"
+    =link_to 'Use the SALSA as a template', template_document_path(lms_course_id: @course_id, id: @existing_document.template_id, org_path: params[:org_path], relink: params[:relink]), {class: 'btn btn-lg btn-primary'}
+
+  =link_to "Create a new SALSA", new_document_path(lms_course_id: @course_id, org_path: params[:org_path], name: @lms_course['name'], relink: params[:relink]), class: "btn btn-lg btn-success"

--- a/app/views/documents/_relink.html.haml
+++ b/app/views/documents/_relink.html.haml
@@ -2,9 +2,11 @@
   -if existing_document?
     - org_path = @existing_document.organization.path
     - if has_role("organization_admin", @existing_document.organization)
+      - params.permit!
+      =link_to "Relink", params.merge(relink: true), class: "btn btn-lg btn-link" unless params[:relink]
       =link_to "Admin", edit_admin_document_path(@existing_document ,org_path: org_path), class: "btn btn-lg btn-link"
     =link_to "Preview", document_path(id: @existing_document.view_id, org_path: org_path), target: :_blank, class: "btn btn-lg btn-default"
     =link_to "Go to the exisitng SALSA", lms_course_document_path(lms_course_id: @course_id, org_path: org_path), class: "btn btn-lg btn-primary"
-    =link_to 'Use the SALSA as a template', template_document_path(lms_course_id: @course_id, id: @existing_document.template_id, org_path: params[:org_path], relink: params[:relink]), {class: 'btn btn-lg btn-primary'}
+    =link_to 'Use the SALSA as a template', template_document_path(lms_course_id: @course_id, id: @existing_document.template_id, org_path: params[:org_path], relink: params[:relink], document_token: params[:document_token]), {class: 'btn btn-lg btn-primary'}
 
-  =link_to "Create a new SALSA", new_document_path(lms_course_id: @course_id, org_path: params[:org_path], name: @lms_course['name'], relink: params[:relink]), class: "btn btn-lg btn-success"
+  =link_to "Create a new SALSA", new_document_path(lms_course_id: @course_id, org_path: params[:org_path], name: @lms_course['name'], relink: params[:relink], document_token: params[:document_token]), class: "btn btn-lg btn-success"

--- a/app/views/documents/course_select.html.haml
+++ b/app/views/documents/course_select.html.haml
@@ -12,7 +12,7 @@
     %b Template.
   - if @existing_document.blank?
     .pull-right
-      %h2=link_to "New Salsa", new_document_path(lms_course_id: @course_id), class: "btn btn-lg btn-success"
+      %h2=link_to "New Salsa", new_document_path(lms_course_id: @course_id, org_path: params[:org_path]), class: "btn btn-lg btn-success"
 
     - locals = { |
       links: [:view, :link, :template], |

--- a/app/views/documents/course_select.html.haml
+++ b/app/views/documents/course_select.html.haml
@@ -1,33 +1,31 @@
-- if !existing_document? || params[:relink]
-  .container.text-left
-    %h1 
-      Select a SALSA for the 
-      %b=@course_id 
-      Course
-    %p.text-justify 
-      ="Create a New document for this course, or Link it to an existing document, or use another document as a Template."
-    .pull-right
-      - relink_locals = {has_existing_document: has_existing_document}
-      =render partial: "relink", locals: relink_locals
-
-    - document_list_locals = { |
-      links: [:view, :link, :template], |
-      columns: [:links, :name, :dates, :lms_course_id], |
-      classes: {template: "btn btn-primary pull-right", link: "btn btn-small btn-info course_select_links"}, |
-      titles: {template: "Use as Template", link: "Link Course", view: "Preview"}, |
-      course_id: @course_id, |
-      relink: params[:relink] |
-      } |
-
-    = render partial: '/admin_documents/list', locals: document_list_locals
-
-- else
-  .container
-    %h1 
-      The 
-      %b=@course_id 
-      Course already exists
+-# if !existing_document? || params[:relink]
+.container.text-left
+  .row
+    - if !existing_document?
+      %h1 
+        Select a SALSA for the 
+        %b=@course_id 
+        Course
+    - else
+      %h1 
+        The 
+        %b=@course_id 
+        Course already exists.
     %p
-      ="Go to the existing SALSA, or use it as a Template for a new document, or Create a SALSA from scratch"
+      ="Go to the existing SALSA, or use it as a Template for a new document, or Create a SALSA from scratch."
+  .row
     - relink_locals = {has_existing_document: has_existing_document}
     =render partial: "relink", locals: relink_locals
+
+  - document_list_locals = { |
+    links: [:view, :link, :template], |
+    columns: [:links, :name, :dates, :lms_course_id], |
+    classes: {template: "btn btn-primary pull-right", link: "btn btn-small btn-info course_select_links"}, |
+    titles: {template: "Use as Template", link: "Link Course", view: "Preview"}, |
+    course_id: @course_id, |
+    relink: params[:relink] |
+    } |
+  - if @documents
+    .text-left.row
+      %h3 My Documents
+      = render partial: '/admin_documents/list', locals: document_list_locals

--- a/app/views/documents/course_select.html.haml
+++ b/app/views/documents/course_select.html.haml
@@ -1,30 +1,31 @@
-.container.text-left
-  .row
-    - if !existing_document?
-      %h1 
-        Select a SALSA for the 
-        %b=@course_id 
-        Course
-    - else
-      %h1 
-        The 
-        %b=@course_id 
-        Course already exists.
-    %p
-      ="Go to the existing SALSA, or use it as a Template for a new document, or Create a SALSA from scratch."
-  .row
-    - relink_locals = {has_existing_document: has_existing_document}
-    =render partial: "relink", locals: relink_locals
+-if existing_document_within_organization? || has_role("organization_admin") || params[:document_token]
+  .container.text-left
+    .row
+      - if !existing_document?
+        %h1 
+          Select a SALSA for the 
+          %b=@course_id 
+          Course
+      - else
+        %h1 
+          The 
+          %b=@course_id 
+          Course already exists.
+      %p
+        ="Go to the existing SALSA, or use it as a Template for a new document, or Create a SALSA from scratch."
+    .row
+      - relink_locals = {has_existing_document: has_existing_document}
+      =render partial: "relink", locals: relink_locals
 
-  - document_list_locals = { |
-    links: [:view, :link, :template], |
-    columns: [:links, :name, :dates, :lms_course_id], |
-    classes: {template: "btn btn-primary pull-right", link: "btn btn-small btn-info course_select_links"}, |
-    titles: {template: "Use as Template", link: "Link Course", view: "Preview"}, |
-    course_id: @course_id, |
-    relink: params[:relink] |
-    } |
-  - if @documents && allow_existing_salsas_for_new_courses
-    .text-left.row
-      %h3 My Documents
-      = render partial: '/admin_documents/list', locals: document_list_locals
+    - document_list_locals = { |
+      links: [:view, :link, :template], |
+      columns: [:links, :name, :dates, :lms_course_id], |
+      classes: {template: "btn btn-primary pull-right", link: "btn btn-small btn-info course_select_links"}, |
+      titles: {template: "Use as Template", link: "Link Course", view: "Preview"}, |
+      course_id: @course_id, |
+      relink: params[:relink] |
+      } |
+    - if @documents && allow_existing_salsas_for_new_courses
+      .text-left.row
+        %h3 My Documents
+        = render partial: '/admin_documents/list', locals: document_list_locals

--- a/app/views/documents/course_select.html.haml
+++ b/app/views/documents/course_select.html.haml
@@ -24,7 +24,7 @@
     course_id: @course_id, |
     relink: params[:relink] |
     } |
-  - if @documents
+  - if @documents && allow_existing_salsas_for_new_courses
     .text-left.row
       %h3 My Documents
       = render partial: '/admin_documents/list', locals: document_list_locals

--- a/app/views/documents/course_select.html.haml
+++ b/app/views/documents/course_select.html.haml
@@ -1,4 +1,3 @@
--# if !existing_document? || params[:relink]
 .container.text-left
   .row
     - if !existing_document?

--- a/app/views/documents/course_select.html.haml
+++ b/app/views/documents/course_select.html.haml
@@ -1,29 +1,33 @@
-.container.text-left
-  %h1 
-    Select a SALSA for the 
-    %b=@course_id 
-    Course
-  %p.text-justify 
-    Create a 
-    %b New 
-    document for this course, or 
-    %b Link
-    it to an existing document, or use another document as a 
-    %b Template.
-  - if @existing_document.blank?
+- if !existing_document? || params[:relink]
+  .container.text-left
+    %h1 
+      Select a SALSA for the 
+      %b=@course_id 
+      Course
+    %p.text-justify 
+      ="Create a New document for this course, or Link it to an existing document, or use another document as a Template."
     .pull-right
-      %h2=link_to "New Salsa", new_document_path(lms_course_id: @course_id, org_path: params[:org_path]), class: "btn btn-lg btn-success"
+      - relink_locals = {has_existing_document: has_existing_document}
+      =render partial: "relink", locals: relink_locals
 
-    - locals = { |
+    - document_list_locals = { |
       links: [:view, :link, :template], |
-      columns: [:org, :links, :name, :dates, :lms_course_id], |
-      classes: {template: "btn btn-primary", link: "btn btn-small btn-info course_select_links"}, |
+      columns: [:links, :name, :dates, :lms_course_id], |
+      classes: {template: "btn btn-primary pull-right", link: "btn btn-small btn-info course_select_links"}, |
       titles: {template: "Use as Template", link: "Link Course", view: "Preview"}, |
-      course_id: @course_id |
+      course_id: @course_id, |
+      relink: params[:relink] |
       } |
 
-    = render partial: '/admin_documents/list', locals: locals
-  - else
-    .pull-right
-      - org_base = org_url_base(@existing_document.organization)
-      %h2=link_to "Go to exisitng document", "#{org_base}#{lms_course_document_path(lms_course_id: @course_id)}", class: "btn btn-lg btn-default"
+    = render partial: '/admin_documents/list', locals: document_list_locals
+
+- else
+  .container
+    %h1 
+      The 
+      %b=@course_id 
+      Course already exists
+    %p
+      ="Go to the existing SALSA, or use it as a Template for a new document, or Create a SALSA from scratch"
+    - relink_locals = {has_existing_document: has_existing_document}
+    =render partial: "relink", locals: relink_locals

--- a/app/views/instances/default/home/_layout_error.html.erb
+++ b/app/views/instances/default/home/_layout_error.html.erb
@@ -5,7 +5,12 @@
   </div>
 <% end %>
 <% if flash[:notice] %>
-  <div class="alert alert-danger">
+  <div class="alert alert-info">
     <%= flash[:notice] %>
+  </div>
+<% end %>
+<% if flash[:warning] %>
+  <div class="alert alert-warning">
+    <%= flash[:warning] %>
   </div>
 <% end %>

--- a/app/views/layouts/relink.html.erb
+++ b/app/views/layouts/relink.html.erb
@@ -21,18 +21,12 @@
     <%= javascript_include_tag "admin" %>
   </head>
   <body>
-    <div class="container-fluid">
+    <div class="container">
       <div class="row">
 
-
-
-
         <div class="col-md-12 text-center">
-          <% if flash[:error] %>
-            <div class="alert alert-danger">
-              <%= flash[:error] %>
-            </div>
-          <% end %>
+
+          <%= salsa_partial "home/layout_error" %>
 
           <%= yield %>
         </div>

--- a/app/views/organizations/_settings.html.erb
+++ b/app/views/organizations/_settings.html.erb
@@ -94,6 +94,13 @@
         <%= f.label :document_search_includes_sub_organizations, "Include Sub-Organizations in Document Searches #{ "(Controlled by root org)" if @organization&.slug&.start_with?("/") }", class: "control-label" %>
       </div>
     </div>
+
+    <div class="form-group">
+      <div class="controls">
+        <%= f.check_box :allow_existing_salsas_for_new_courses, class: '' , "#{"disabled" if @organization&.slug&.start_with?("/")}".to_sym => true %>
+        <%= f.label :allow_existing_salsas_for_new_courses, "Allow users to select from their documents for new courses #{ "(Controlled by root org)" if @organization&.slug&.start_with?("/") }", class: "control-label" %>
+      </div>
+    </div>
     
     <div class="form-group">
       <div class="controls">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
             post '/auth/shibboleth', to: 'users/saml_sessions#create'
         end
         resources :documents, path: 'SALSA', constraints: { slug: /.*/ }
+        get 'SALSA/:id/template', to: 'documents#template', as: 'template_document', constraints: { slug: /.*/ }
         get 'documents/:document_id/meta', to: 'admin_documents#meta', as: 'document_meta', constraints: { slug: /.*/ }
         scope 'workflow' do
             get 'documents/assignments', as: 'workflow_document_assignments', to: 'workflow_documents#assignments'
@@ -120,7 +121,7 @@ Rails.application.routes.draw do
         get '/lms/courses', to: 'documents#course_list', as: 'lms_course_list'
         get '/lms/courses/:lms_course_id', to: 'documents#course', as: 'lms_course_document'
         get '/lms/courses/:lms_course_id/select', to: 'documents#course_select', as: 'lms_course_select'
-        get '/lms/courses/:lms_course_id/link/:edit_id', to: 'documents#course_link', as: 'lms_course_link'
+        get '/lms/courses/:lms_course_id/link/:id', to: 'documents#course_link', as: 'link_lms_course'
         get '/lms/courses/:lms_course_id/version/:version', to: 'documents#course', as: 'lms_course_document_history'
 
         post '/lti/init', to: 'lti#init', as: 'lti_init'

--- a/db/migrate/20191125233656_add_allow_existing_salsas_for_new_courses_to_organizations.rb
+++ b/db/migrate/20191125233656_add_allow_existing_salsas_for_new_courses_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddAllowExistingSalsasForNewCoursesToOrganizations < ActiveRecord::Migration[5.1]
+  def change
+    add_column :organizations, :allow_existing_salsas_for_new_courses, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190930174239) do
+ActiveRecord::Schema.define(version: 20191125233656) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -167,6 +167,7 @@ ActiveRecord::Schema.define(version: 20190930174239) do
     t.string "name_reports_by"
     t.string "time_zone"
     t.boolean "document_search_includes_sub_organizations", default: false, null: false
+    t.boolean "allow_existing_salsas_for_new_courses", default: false
     t.index ["depth"], name: "index_organizations_on_depth"
     t.index ["lft"], name: "index_organizations_on_lft"
     t.index ["lms_id"], name: "index_organizations_on_lms_id"


### PR DESCRIPTION
The context is that a request for a course has comes in from an LMS

When a document with the requested course belongs to an organization but my org_path points a separate organization in the same tree. 
Before: Then some of the links don't work.
now: The links work and it gives you a warning that this course belongs to another organization in the tree, and by clicking 'create new' or 'use as template' you will steal the course from the existing document.

When no document matches the course and my requests org_path pointed to a sub organization. 
When I click create new SLASA
Before: it creates the new document on the root organization And tries to redirect to the course but cant find the course on the sub organization (and see issue above)
Now: It removes the course from the existing document and creates a new salsa with the course.

both the 'link course' and 'use as template' buttons have similar changes.   




