### PR TITLE
hotfix / document#course redirects to the correct org_path by organizations lms_account_id

### DIFF
--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -33,6 +33,17 @@ module DocumentsHelper
   def existing_document_within_organization? org: @organization, doc: @existing_document
     @is_existing_document_within_organization ||= @organization&.id == doc&.organization&.id
   end
+  
+  def lms_account_course_document_path
+    org = get_org_by_lms_account_id
+    params.permit!
+    lms_course_document_path( {org_path: org.path, lms_course_id: params[:lms_course_id]}.merge(params.except(:lms_course_id,:org_path, :action, :controller)))
+  end
 
+  def get_org_by_lms_account_id
+    get_organization unless @organization
+    get_lms_course( @organization.root_org_setting('lms_authentication_source') ) unless @lms_course
+    @organization.root.self_and_descendants.find_by_lms_account_id(@lms_course['account_id'].to_s)
+  end
 
 end

--- a/app/views/documents/_relink.html.haml
+++ b/app/views/documents/_relink.html.haml
@@ -4,7 +4,7 @@
     - if has_role("organization_admin", @existing_document.organization)
       - params.permit!
       =link_to "Relink", params.merge(relink: true), class: "btn btn-lg btn-link" unless params[:relink]
-      =link_to "Admin", edit_admin_document_path(@existing_document ,org_path: org_path), class: "btn btn-lg btn-link"
+      =link_to "Properties", edit_admin_document_path(@existing_document ,org_path: org_path), class: "btn btn-lg btn-link"
     - if @existing_document&.lms_course_id == @course_id
       =link_to "Preview", document_path(id: @existing_document.view_id, org_path: org_path), target: :_blank, class: "btn btn-lg btn-default"
       =link_to "Go to the course", lms_course_document_path(lms_course_id: @course_id, org_path: org_path), class: "btn btn-lg btn-primary"


### PR DESCRIPTION
a request from canvas dose not have the org_path, so redirect them to the right path using the lms_account_id from an organization.