### PR TITLE
bugfix/don't override existing data when the dynamic data returns a blank string

### DIFF
--- a/app/assets/javascripts/script.js
+++ b/app/assets/javascripts/script.js
@@ -111,9 +111,12 @@ function liteOff(x) {
 
         if(elementText === '') {
           elementText = '{{'+reference+'}}';
+          if (element.text() == '' || element.text().search(/\{\{[^\}]+\}\}/) > -1) {
+            element.text(elementText);
+          }
+        } else {
+          element.text(elementText);
         }
-
-        element.text(elementText);
 
         if(elementText && elementText.search(/\{\{[^\}]+\}\}/) < 0) {
           element.removeClass('editable').removeAttr('tabindex');


### PR DESCRIPTION
before:
when the dynamic data returned a blank string it would override any existing text in the element with  `{{<data-dynamic-attribute>}}`.
now:
when the dynamic data returns a blank string it checks if the element text is blank
if so it sets the field to `{{<data-dynamic-attribute>}}` 
else it dose nothing.